### PR TITLE
fix: dockerfile labels and cosign

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -60,10 +60,6 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      
-      - name: set CREATION_DATETIME variable
-        run: |
-          echo "CREATION_DATETIME=$(date --rfc-3339=seconds | sed 's/ /T/')" >> ${GITHUB_ENV}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -75,10 +71,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            IMAGE_VERSION=${{ steps.meta.outputs.version }}
-            IMAGE_CREATION_DATETIME=${{ env.CREATION_DATETIME }}
-            IMAGE_GIT_SHA1=$GITHUB_SHA
 
 
       # Sign the resulting Docker image digest except on PRs.
@@ -89,7 +81,7 @@ jobs:
       - name: Sign the image with GitHub OIDC Token 
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          TAGS: ${{ steps.meta.outputs.tags }}
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ ARG AZ_CLI_VERSION=2.34.1
 ARG SQL_PACKAGE_VERSION=16.0.5400.1
 ARG MSSQL_TOOLS_VERSION=17.9.1.1-1
 
-ARG IMAGE_VERSION
-ARG IMAGE_CREATION_DATETIME
-ARG IMAGE_GIT_SHA1
-
 # Retrieve terraform binary from official terraform docker image
 FROM hashicorp/terraform:${TERRAFORM_VERSION} as terraform
 
@@ -28,11 +24,6 @@ FROM ubuntu:${UBUNTU_BASE_IMAGE_VERSION} as release
 ARG PYTHON_MAJOR_MINOR_VERSION
 ARG SQL_PACKAGE_VERSION
 ARG MSSQL_TOOLS_VERSION
-
-ARG IMAGE_VERSION
-ARG IMAGE_CREATION_DATETIME
-ARG IMAGE_GIT_SHA1
-
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python${PYTHON_MAJOR_MINOR_VERSION} python3-distutils curl unzip libunwind8 libicu66 jq git gnupg ca-certificates \
@@ -57,14 +48,3 @@ COPY --from=azure-cli /usr/lib/python3/dist-packages /usr/lib/python3/dist-packa
 
 USER nonroot
 ENTRYPOINT [ "/bin/bash" ]
-
-# https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.title="terraform-azure"
-LABEL org.opencontainers.image.description="Docker image for CI/CD usage, contains Terraform, Azure and SQL Server tools, based on Ubuntu."
-LABEL org.opencontainers.image.authors="Michaël Bertoni"
-LABEL org.opencontainers.image.url="https://github.com/michaelbertoni/terraform-azure-docker"
-LABEL org.opencontainers.image.source="https://github.com/michaelbertoni/terraform-azure-docker"
-LABEL org.opencontainers.image.version="${IMAGE_VERSION}"
-LABEL org.opencontainers.image.created="${IMAGE_CREATION_DATETIME}"
-LABEL org.opencontainers.image.revision="${IMAGE_GIT_SHA1}"
-LABEL org.opencontainers.image.licenses="MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENTRYPOINT [ "/bin/bash" ]
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.title="terraform-azure"
 LABEL org.opencontainers.image.description="Docker image for CI/CD usage, contains Terraform, Azure and SQL Server tools, based on Ubuntu."
-LABEL org.opencontainers.image.authors ="Michaël Bertoni"
+LABEL org.opencontainers.image.authors="Michaël Bertoni"
 LABEL org.opencontainers.image.url="https://github.com/michaelbertoni/terraform-azure-docker"
 LABEL org.opencontainers.image.source="https://github.com/michaelbertoni/terraform-azure-docker"
 LABEL org.opencontainers.image.version="${IMAGE_VERSION}"


### PR DESCRIPTION
Dockerfile was duplicating LABEL commands that are already set by the docker/metadata-action workflow step, we are removing them.

cosign workflow step was targeting a wrong step id, this is fixed.